### PR TITLE
Point to latest image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
       - name: Set up Git repository
         uses: actions/checkout@v1
       - name: Compile LaTeX document
-        uses: dante-ev/latex-action@master
+        uses: dante-ev/latex-action@latest
         with:
           root_file: Main.tex
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
We try to move away from `master`.

`latest` is the latest release; `edge` would be the latest development version. I am not sure whether you would like to have stable builds or always use the latest texlive packages?